### PR TITLE
Use folder of current text editor as working directory

### DIFF
--- a/lib/swank-starter.coffee
+++ b/lib/swank-starter.coffee
@@ -18,6 +18,8 @@ class SwankStarter
     @process = new BufferedProcess({
       command: command,
       args: args,
+      options:
+        cwd: @get_cwd()
       stdout: @stdout_callback,
       stderr: @stderr_callback,
       exit: @exit_callback
@@ -43,6 +45,11 @@ class SwankStarter
 
   stderr_callback: (output) ->
     #console.log output
+
+  get_cwd: ->
+    ed = atom.workspace.getActiveTextEditor()?.getPath()
+    return atom.project.getPaths()[0] unless ed?
+    return path.dirname(ed)
 
   exit_callback: (code) ->
     console.log "Lisp process exited: #{code}"


### PR DESCRIPTION
This PR changes the working directory of the swank server (if started with `slime:start`) depending on your current workspace:

* If there is an active text editor, use the folder of the currently active file.
* If there are open projects, use the path of the first one.
* Use atom's current working directory as a fallback.

There is no problem if you start atom in your project folder, but I always start atom in my home folder and add/remove project folders instead of restarting atom.
With this PR I can `slime:start` in my lisp project and `(load ...)` my files more easily.

Let me know what you think.

BTW great job on this package. I love it :wink: