### PR TITLE
Support Common Lisp as well as Lisp syntax

### DIFF
--- a/lib/atom-slime.coffee
+++ b/lib/atom-slime.coffee
@@ -52,12 +52,12 @@ module.exports = AtomSlime =
 
     # Keep track of all Lisp editors
     @subs.add atom.workspace.observeTextEditors (editor) =>
-      if editor.getGrammar().name == "Lisp"
+      if editor.getGrammar().name.search /Lisp/
         ase = new AtomSlimeEditor(editor, @views.statusView, @swank)
         @ases.add ase
       else
         editor.onDidChangeGrammar =>
-          if editor.getGrammar().name == "Lisp"
+          if editor.getGrammar().name.search /Lisp/
             ase = new AtomSlimeEditor(editor, @views.statusView, @swank)
             @ases.add ase
 


### PR DESCRIPTION
I am using https://atom.io/packages/language-common-lisp instead of the `language-lisp` package, because I find the syntax highlighting more accurate.

However, currently the `Slime: Goto definition` and `Slime: Compile function` commands don't pop up when I change the file to `Common Lisp`
from `Lisp`.

This should fix that and allow me to use those commands, while using the `language-common-lisp` syntax highlighting.