### PR TITLE
Reuse repl feature

### DIFF
--- a/keymaps/atom-slime.cson
+++ b/keymaps/atom-slime.cson
@@ -11,10 +11,12 @@
 'atom-text-editor[data-grammar~="lisp"]':
     'alt-.': 'slime:goto-definition'
     'alt-c': 'slime:compile-function'
+    'alt-k': 'slime:compile-buffer'
 
 'atom-text-editor':
     'ctrl-cmd-.': 'slime:goto-definition'
     'ctrl-cmd-c': 'slime:compile-function'
+    'ctrl-cmd-k': 'slime:compile-buffer'
 
 
 'atom-text-editor.slime-repl':

--- a/lib/atom-slime-editor.coffee
+++ b/lib/atom-slime-editor.coffee
@@ -25,6 +25,8 @@ class AtomSlimeEditor
       @openDefinition()
     @subs.add atom.commands.add @editorElement, 'slime:compile-function': =>
       @compileFunction()
+    @subs.add atom.commands.add @editorElement, 'slime:compile-buffer': =>
+      @compileBuffer()
 
     # Pretend we just finished editing, so that way things get up to date
     @stoppedEditingCallback()
@@ -126,6 +128,13 @@ class AtomSlimeEditor
         # Trigger the highlight effect
         range = Range(p_start, p_end)
         utils.highlightRange(range, @editor, delay=250)
+
+  compileBuffer: ->
+    # Compile the entire buffer
+    if @swank.connected
+      text = @editor.getText();
+      @swank.compile_string(text, @editor.getTitle(), @editor.getPath(), 0, 0, @pkg)
+      utils.highlightRange(Range([0, 0], @convertIndexToPoint(text.length - 1)), @editor, delay=250)
 
   editorDestroyedCallback: ->
     console.log "Closed!"

--- a/lib/atom-slime-repl-view.coffee
+++ b/lib/atom-slime-repl-view.coffee
@@ -28,7 +28,7 @@ class REPLView
     @editor = @replPane = null
     editors = atom.workspace.getTextEditors()
     for editor in editors
-      if editor.getPath() == '/tmp/repl.lisp-repl'
+      if editor.getTitle() == 'repl.lisp-repl'
         # We found the editor! Now search for the pane it's in.
         allPanes = atom.workspace.getPanes()
         for pane in allPanes

--- a/lib/swank-starter.coffee
+++ b/lib/swank-starter.coffee
@@ -15,7 +15,10 @@ class SwankStarter
       return false
     command = @lisp
     args = []
-    args.push '--load' unless command.match(/clisp/)  # CLISP does not have a --load option
+    if not command.match(/clisp|lw/)
+      args.push '--load'
+    else
+      args.push '-load' if command.match(/lw/)
     args.push @swank_script
     @process = new BufferedProcess({
       command: command,


### PR DESCRIPTION
On Mac, at least, the REPL path is ‘/private/tmp/repl.lisp-repl’ rather
than the ‘/tmp/repl.lisp-repl’ requested.
Fixes bug #19 on sjlevine/atom-slime
