### PR TITLE
support roswell

### DIFF
--- a/lib/swank-starter.coffee
+++ b/lib/swank-starter.coffee
@@ -15,6 +15,7 @@ class SwankStarter
       return false
     command = @lisp
     args = []
+    args.push 'run' if command.match(/ros/)
     args.push '--load' unless command.match(/clisp/)  # CLISP does not have a --load option
     args.push @swank_script
     @process = new BufferedProcess({


### PR DESCRIPTION
This is patch to use [roswell](https://github.com/roswell/roswell) implementation installer and selecter.
just add 'run' on arg before '--load' option.
