### PR TITLE
Fix #47 (CoffeeScript Upgrade)

### DIFF
--- a/lib/atom-slime-editor.coffee
+++ b/lib/atom-slime-editor.coffee
@@ -15,9 +15,9 @@ class AtomSlimeEditor
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     @editorElement = atom.views.getView(@editor)
     @subs = new CompositeDisposable
-    @subs.add editor.onDidStopChanging => @stoppedEditingCallback()
-    @subs.add editor.onDidChangeCursorPosition => @cursorMovedCallback()
-    @subs.add editor.onDidDestroy => @editorDestroyedCallback()
+    @subs.add @editor.onDidStopChanging => @stoppedEditingCallback()
+    @subs.add @editor.onDidChangeCursorPosition => @cursorMovedCallback()
+    @subs.add @editor.onDidDestroy => @editorDestroyedCallback()
 
     # TODO - make this a context menu item... not a command that only works through
     # command pallette in that window...


### PR DESCRIPTION
Used `@editor` instead of `editor` which fixes an `editor is not defined` exception when opening lisp files.
