### PR TITLE
fix: added option to pass arguments to the lisp process

### DIFF
--- a/lib/atom-slime.coffee
+++ b/lib/atom-slime.coffee
@@ -21,13 +21,27 @@ module.exports = AtomSlime =
       description: 'Path to where SLIME resides on your computer.'
       type: 'string'
       default: '/home/username/Desktop/slime'
-      order: 3
+      order: 5
 
     lispName:
       title: 'Lisp Process'
       description: 'Name of Lisp to run'
       type: 'string'
       default: 'sbcl'
+      order: 4
+
+    lispOptionsString:
+      title: 'Additional options for the Lisp process'
+      description: ''
+      type: 'string'
+      default: '--no-linedit'
+      order: 3
+
+    lispOptionsEnabled:
+      title: 'Enable Lisp process options'
+      description: 'When checked, the Lisp process with started with supplied options.'
+      type: 'boolean'
+      default: false
       order: 2
 
     autoStart:

--- a/lib/swank-starter.coffee
+++ b/lib/swank-starter.coffee
@@ -14,6 +14,8 @@ class SwankStarter
       atom.notifications.addWarning("Did you set up `atom-slime` as noted in the package's preferences? The \"Slime Path\" directory can't be opened. Please double check it!")
       return false
     command = @lisp
+    @lispOptionsString = atom.config.get 'atom-slime.lispOptionsString'
+    @lispOptionsEnabled = atom.config.get 'atom-slime.lispOptionsEnabled'
     args = []
     args.push 'run' if command.match(/ros/)
     if not command.match(/clisp|lw/)
@@ -21,6 +23,7 @@ class SwankStarter
     else
       args.push '-load' if command.match(/lw/)
     args.push @swank_script
+    args.push @lispOptionsString if @lispOptionsEnabled
     @process = new BufferedProcess({
       command: command,
       args: args,

--- a/menus/atom-slime.cson
+++ b/menus/atom-slime.cson
@@ -10,6 +10,10 @@
           'command': 'slime:start'
         },
         {
+          'label': 'Connect',
+          'command': 'slime:connect'
+        },
+        {
           'label': 'Disconnect',
           'command': 'slime:disconnect'
         },


### PR DESCRIPTION
I use [linedit](https://common-lisp.net/project/linedit/) for [sbcl](http://sbcl.org/), and use the `--no-linedit` command line switch, as suggested by _linedit_. For [GNU Emacs](https://www.gnu.org/software/emacs/) with [slime]() the following statement should be added to `.emacs':

```lisp
(setq inferior-lisp-program "sbcl --noinform --no-linedit")
```

I run into some problems with `atom-slime` without this command line argument. Because I didn't want to write a shell wrapper for slime, I started to create this little fix.

It adds a string to be passed to the Lisp process (default value is `--no-linedit`) and has a switch to enable passing this string (default value is `false`).

I also added a "Slime -> Connect" menu entry. It may be a bit more convenient than `Ctrl-Shift-P`.