### PR TITLE
Add support for multiline input

### DIFF
--- a/lib/atom-slime-repl-view.coffee
+++ b/lib/atom-slime-repl-view.coffee
@@ -198,9 +198,8 @@ class REPLView
 
     input = @getUserInput()
     ast = paredit.parse(input)
-    if ast.errors.length > 0
+    if ast.errors.find((err) -> err.error.indexOf('but reached end of input') != -1)
       # missing ending parenthesis, use default system to add newline
-      console.log ast.errors
       return
 
     # Push this command to the ring if applicable


### PR DESCRIPTION
Fixes #24 and follows the decision there that using paredit is the best approach.
When the user presses enter in the REPL, if there are missing close braces it adds a newline instead of evaluating it.  (In particular it parses the existing input with paredit and checks for any error containing "but reached end of input").
I went with only adding the newline when the end of input message arises since it seems like other syntax issues would be mistakes instead of wanting a newline.  Although, that limit can be removed by skipping commit `8e0f53f`.

There's also some improvement for support of multiple cursors, since I had to rewrite those sections already.  Plus I removed a few redundant checks since I was looking at `promptMarker` code anyways